### PR TITLE
Separate changelog building from `resource.h`

### DIFF
--- a/hlp/changelog_shell.htm
+++ b/hlp/changelog_shell.htm
@@ -26,7 +26,7 @@
 
 <div class="markdown-body">
 <!-- if you can't see the HTML, it may have not been inserted yet. -->
-<!-- INSERT-CHANGELOG-HERE -->
+PATCH CHANGELOG HERE
 </div>
 
 		<hr>

--- a/hlp/hlp.vcxproj
+++ b/hlp/hlp.vcxproj
@@ -396,6 +396,65 @@ echo.</Command>
     <None Include="changelog.htm">
       <DeploymentContent>true</DeploymentContent>
     </None>
+    <CustomBuild Include="changelog_shell.htm">
+      <DeploymentContent>true</DeploymentContent>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">powershell -Command "(Get-Content $(SolutionDir)Dn-help\hlp\changelog_shell.htm).Replace('PATCH CHANGELOG HERE', (pandoc $(SolutionDir)docs/CHANGELOG.md -f gfm -t html5)) | Set-Content -encoding UTF8 $(SolutionDir)Dn-help\hlp\changelog.htm"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">Updating changelog.htm.</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(ProjectDir)changelog.htm;%(Outputs)</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='ASAN-Debug|Win32'">powershell -Command "(Get-Content $(SolutionDir)Dn-help\hlp\changelog_shell.htm).Replace('PATCH CHANGELOG HERE', (pandoc $(SolutionDir)docs/CHANGELOG.md -f gfm -t html5)) | Set-Content -encoding UTF8 $(SolutionDir)Dn-help\hlp\changelog.htm"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='ASAN-Debug|Win32'">Updating changelog.htm.</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='ASAN-Debug|Win32'">$(ProjectDir)changelog.htm;%(Outputs)</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='ASAN-Release|Win32'">powershell -Command "(Get-Content $(SolutionDir)Dn-help\hlp\changelog_shell.htm).Replace('PATCH CHANGELOG HERE', (pandoc $(SolutionDir)docs/CHANGELOG.md -f gfm -t html5)) | Set-Content -encoding UTF8 $(SolutionDir)Dn-help\hlp\changelog.htm"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='ASAN-Release|Win32'">Updating changelog.htm.</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='ASAN-Release|Win32'">$(ProjectDir)changelog.htm;%(Outputs)</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">powershell -Command "(Get-Content $(SolutionDir)Dn-help\hlp\changelog_shell.htm).Replace('PATCH CHANGELOG HERE', (pandoc $(SolutionDir)docs/CHANGELOG.md -f gfm -t html5)) | Set-Content -encoding UTF8 $(SolutionDir)Dn-help\hlp\changelog.htm"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">Updating changelog.htm.</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">$(ProjectDir)changelog.htm;%(Outputs)</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">powershell -Command "(Get-Content $(SolutionDir)Dn-help\hlp\changelog_shell.htm).Replace('PATCH CHANGELOG HERE', (pandoc $(SolutionDir)docs/CHANGELOG.md -f gfm -t html5)) | Set-Content -encoding UTF8 $(SolutionDir)Dn-help\hlp\changelog.htm"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Updating changelog.htm.</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">$(ProjectDir)changelog.htm;%(Outputs)</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='ASAN-Debug|x64'">powershell -Command "(Get-Content $(SolutionDir)Dn-help\hlp\changelog_shell.htm).Replace('PATCH CHANGELOG HERE', (pandoc $(SolutionDir)docs/CHANGELOG.md -f gfm -t html5)) | Set-Content -encoding UTF8 $(SolutionDir)Dn-help\hlp\changelog.htm"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='ASAN-Debug|x64'">Updating changelog.htm.</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='ASAN-Debug|x64'">$(ProjectDir)changelog.htm;%(Outputs)</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='ASAN-Release|x64'">powershell -Command "(Get-Content $(SolutionDir)Dn-help\hlp\changelog_shell.htm).Replace('PATCH CHANGELOG HERE', (pandoc $(SolutionDir)docs/CHANGELOG.md -f gfm -t html5)) | Set-Content -encoding UTF8 $(SolutionDir)Dn-help\hlp\changelog.htm"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='ASAN-Release|x64'">Updating changelog.htm.</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='ASAN-Release|x64'">$(ProjectDir)changelog.htm;%(Outputs)</Outputs>
+      <Command Condition="'$(Configuration)|$(Platform)'=='Release|x64'">powershell -Command "(Get-Content $(SolutionDir)Dn-help\hlp\changelog_shell.htm).Replace('PATCH CHANGELOG HERE', (pandoc $(SolutionDir)docs/CHANGELOG.md -f gfm -t html5)) | Set-Content -encoding UTF8 $(SolutionDir)Dn-help\hlp\changelog.htm"</Command>
+      <Message Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Updating changelog.htm.</Message>
+      <Outputs Condition="'$(Configuration)|$(Platform)'=='Release|x64'">$(ProjectDir)changelog.htm;%(Outputs)</Outputs>
+      <BuildInParallel Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</BuildInParallel>
+      <BuildInParallel Condition="'$(Configuration)|$(Platform)'=='ASAN-Debug|Win32'">true</BuildInParallel>
+      <BuildInParallel Condition="'$(Configuration)|$(Platform)'=='ASAN-Release|Win32'">true</BuildInParallel>
+      <BuildInParallel Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</BuildInParallel>
+      <BuildInParallel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</BuildInParallel>
+      <BuildInParallel Condition="'$(Configuration)|$(Platform)'=='ASAN-Debug|x64'">true</BuildInParallel>
+      <BuildInParallel Condition="'$(Configuration)|$(Platform)'=='ASAN-Release|x64'">true</BuildInParallel>
+      <BuildInParallel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</BuildInParallel>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='ASAN-Debug|Win32'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='ASAN-Release|Win32'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='ASAN-Debug|x64'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='ASAN-Release|x64'">true</DeploymentContent>
+      <DeploymentContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</DeploymentContent>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">false</LinkObjects>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">true</TreatOutputAsContent>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='ASAN-Debug|Win32'">false</LinkObjects>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='ASAN-Debug|Win32'">true</TreatOutputAsContent>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='ASAN-Release|Win32'">false</LinkObjects>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='ASAN-Release|Win32'">true</TreatOutputAsContent>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">false</LinkObjects>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">true</TreatOutputAsContent>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</LinkObjects>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</TreatOutputAsContent>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='ASAN-Debug|x64'">false</LinkObjects>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='ASAN-Debug|x64'">true</TreatOutputAsContent>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='ASAN-Release|x64'">false</LinkObjects>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='ASAN-Release|x64'">true</TreatOutputAsContent>
+      <LinkObjects Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</LinkObjects>
+      <TreatOutputAsContent Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</TreatOutputAsContent>
+    </CustomBuild>
     <None Include="command_line.htm">
       <DeploymentContent>true</DeploymentContent>
     </None>

--- a/hlp/hlp.vcxproj.filters
+++ b/hlp/hlp.vcxproj.filters
@@ -221,6 +221,7 @@
     <CustomBuild Include="Dn-FamiTracker.hhp">
       <Filter>HTML Help Files</Filter>
     </CustomBuild>
+    <CustomBuild Include="changelog_shell.htm" />
   </ItemGroup>
   <ItemGroup>
     <Image Include="img\bookmark_manager.png">


### PR DESCRIPTION
This pull request aims to separate `changelog.htm` compiling from the Custom Build Command in `resource.h`.

This pull request corresponds to Dn-Programming-Core-Management/Dn-FamiTracker#354.

### Changes in this PR:

- Implement separate changelog build command
- Refactor patch keyword to not use a comment
