### PR TITLE
Fix spelling error in Export Wave page

### DIFF
--- a/hlp/export_wave.htm
+++ b/hlp/export_wave.htm
@@ -29,7 +29,7 @@
 
     <p class="text">Selects the channels to be audible in export.</p>
 
-<h2 class="bold">Seperate channel export</h2>
+<h2 class="bold">Separate channel export</h2>
 
     <p class="text">If enabled, exports a single isolated wave file for each 
     channel selected in the Channels list.</p>


### PR DESCRIPTION
This pull request aims to fix a spelling error in Export Wave page.

This pull request corresponds to Dn-Programming-Core-Management/Dn-FamiTracker#346.

### Changes in this PR:

- Fix Export Wave page spelling error
